### PR TITLE
Center emphasis function

### DIFF
--- a/data/underlives.yaml
+++ b/data/underlives.yaml
@@ -3,13 +3,11 @@
 # absent: 欠席メンバーの id と理由
 # centers: センターメンバー（省略可）
 #   id: member_ids に含まれる id
-#   scope: "all" | "day1" | "day2" | "day3"
 #   label: 表示ラベル（省略時: 1名→"C", 複数→"WC"）
 #
 # 例:
 #   centers:
 #      id: okamoto_hina
-#        scope: all
 
 - id: ul_41st_2026
   title: "41stSGアンダーライブ"
@@ -22,7 +20,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/page/underlive"
   centers:
     - id: okamoto_hina
-      scope: all
   member_ids:
     - ito_riria
     - iwamoto_renka
@@ -56,7 +53,6 @@
   source_url: "https://www.eventernote.com/events/449940"
   centers:
     - id: ioki_mao
-      scope: all
   member_ids:
     - ioki_mao
     - ito_riria
@@ -85,7 +81,6 @@
   source_url: "https://www.eventernote.com/events/437007"
   centers:
     - id: kanagawa_saya
-      scope: all
   member_ids:
     - ito_riria
     - iwamoto_renka
@@ -110,7 +105,6 @@
   source_url: "https://www.eventernote.com/events/421053"
   centers:
     - id: shibata_yuna
-      scope: all
   member_ids:
     - iwamoto_renka
     - okamoto_hina
@@ -136,7 +130,6 @@
   source_url: "https://www.eventernote.com/events/401362"
   centers:
     - id: tomisato_nao
-      scope: all
   member_ids:
     - ito_riria
     - okamoto_hina
@@ -171,7 +164,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/100560"
   centers:
     - id: okuda_iroha
-      scope: all
   member_ids:
     - ito_riria
     - okamoto_hina
@@ -200,7 +192,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/100304"
   centers:
     - id: tsutsui_ayame
-      scope: all
   member_ids:
     - okamoto_hina
     - ogawa_aya
@@ -232,7 +223,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/66904"
   centers:
     - id: nakanishi_aruno
-      scope: all
   member_ids:
     - ito_riria
     - okamoto_hina
@@ -261,7 +251,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/66711"
   centers:
     - id: matsuo_miyu
-      scope: all
   member_ids:
     - ogawa_aya
     - okuda_iroha
@@ -294,9 +283,7 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/66268"
   centers:
     - id: ito_riria
-      scope: all
     - id: hayashi_runa
-      scope: all
   member_ids:
     - ikeda_teresa
     - ito_riria
@@ -335,7 +322,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/65967"
   centers:
     - id: nakamura_reno
-      scope: all
   member_ids:
     - ito_riria
     - kitagawa_yuri
@@ -363,7 +349,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/65811"
   centers:
     - id: wada_maaya
-      scope: all
   member_ids:
     - ito_riria
     - kitagawa_yuri
@@ -392,7 +377,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/65310"
   centers:
     - id: sato_kaede
-      scope: all
   member_ids:
     - ito_riria
     - kanagawa_saya
@@ -423,7 +407,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/63880"
   centers:
     - id: terada_ranze
-      scope: all
   member_ids:
     - ito_riria
     - kanagawa_saya
@@ -455,7 +438,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/61398"
   centers:
     - id: yamazaki_reina
-      scope: all
   member_ids:
     - ito_junna
     - ito_riria
@@ -483,7 +465,6 @@
   source_url: "https://www.nogizaka46.com/s/n46/news/detail/58998"
   centers:
     - id: sakaguchi_tamami
-      scope: all
   member_ids:
     - ito_junna
     - ito_riria

--- a/src/App.css
+++ b/src/App.css
@@ -308,29 +308,6 @@ h1 {
 	flex-shrink: 0;
 }
 
-/* 日別タブ */
-.day-tabs {
-	display: flex;
-	gap: 0.5rem;
-	margin-bottom: 0.75rem;
-}
-
-.day-tab {
-	padding: 0.3rem 0.8rem;
-	font-size: 0.85rem;
-	border: 1px solid #ccc;
-	border-radius: 4px;
-	background: #fff;
-	cursor: pointer;
-	color: #666;
-}
-
-.day-tab.active {
-	border-color: #333;
-	background: #333;
-	color: #fff;
-}
-
 @media (max-width: 900px) {
 	.card-grid {
 		grid-template-columns: repeat(3, 1fr);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,6 @@ import type { Member, Underlive } from "./types";
 import { getTextColor, isValidHex } from "./utils";
 import "./App.css";
 
-const DAY_TABS = ["all", "day1", "day2", "day3"] as const;
-
 const COLOR_CYCLE = [
 	"白",
 	"オレンジ",
@@ -77,8 +75,6 @@ function UnderlivePanel({
 	members: Member[];
 }) {
 	const [selectedId, setSelectedId] = useState(underlives[0]?.id ?? "");
-	const [dayTab, setDayTab] = useState<string>("all");
-
 	const selected = useMemo(
 		() => underlives.find((u) => u.id === selectedId),
 		[underlives, selectedId],
@@ -109,17 +105,10 @@ function UnderlivePanel({
 		return result;
 	}, [selected, memberMap]);
 
-	const hasDayScoped =
-		selected?.centers?.some((c) => c.scope !== "all") ?? false;
-
 	const activeCenterIds = useMemo(() => {
 		if (!selected?.centers) return new Set<string>();
-		return new Set(
-			selected.centers
-				.filter((c) => c.scope === "all" || c.scope === dayTab)
-				.map((c) => c.id),
-		);
-	}, [selected, dayTab]);
+		return new Set(selected.centers.map((c) => c.id));
+	}, [selected]);
 
 	const sortedMembers = useMemo(() => {
 		if (!activeCenterIds.size) return activeMembers;
@@ -174,21 +163,6 @@ function UnderlivePanel({
 							)}
 						</div>
 					</div>
-
-					{hasDayScoped && (
-						<div className="day-tabs">
-							{DAY_TABS.map((d) => (
-								<button
-									key={d}
-									type="button"
-									className={dayTab === d ? "day-tab active" : "day-tab"}
-									onClick={() => setDayTab(d)}
-								>
-									{d === "all" ? "ALL" : d.toUpperCase()}
-								</button>
-							))}
-						</div>
-					)}
 
 					<div className="member-count">
 						出演メンバー {sortedMembers.length}名

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,11 +13,8 @@ export interface AbsentMember {
 	note?: string;
 }
 
-export type CenterScope = "all" | `day${number}`;
-
 export interface Center {
 	id: string;
-	scope: CenterScope;
 	label?: string;
 }
 


### PR DESCRIPTION
## Overview

This pull request adds support for representing and displaying center members for each Underlive event, including handling day-specific centers and visually highlighting them in the UI. The most important changes are grouped below.

**Data model enhancements:**

* Added a `centers` field to each Underlive entry in `data/underlives.yaml`, allowing specification of center members, their scope (e.g., "all", "day1"), and optional labels. [[1]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R4-R13) [[2]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R24-R26) [[3]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R58-R60) [[4]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R87-R89) [[5]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R112-R114) [[6]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R138-R140) [[7]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R173-R175) [[8]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R202-R204) [[9]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R234-R236) [[10]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R263-R265) [[11]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R296-R300) [[12]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R337-R339) [[13]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R365-R367) [[14]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R394-R396) [[15]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R425-R427) [[16]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R457-R459) [[17]](diffhunk://#diff-bdf90270f0ac8ad10feaebd11033b65a523488cb94394c6fc80008a79ab96ac8R485-R487)
* Introduced new types `CenterScope` and `Center` in `src/types.ts` to model center members and their scope, and updated the `Underlive` interface to include the optional `centers` field. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR16-R23) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR33)

**UI and logic improvements:**

* Updated `UnderlivePanel` in `src/App.tsx` to support day tabs when centers have day-specific scopes, filter and sort members to show centers first, and highlight center members. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R7-R8) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R80) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R112-R130) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R178-R202)
* Modified the `MemberCard` component to accept an `isCenter` prop and visually emphasize center members, including a badge. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L21-R29) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L30-R44)

**Styling changes:**

* Added CSS styles in `src/App.css` to visually highlight center cards and badges, and style day tabs for selecting day-specific centers.