### PR TITLE
Show member call instead of generation

### DIFF
--- a/data/members.yaml
+++ b/data/members.yaml
@@ -358,7 +358,7 @@
   color2_name: 赤
   icon: /icons/sample.png
   active: true
-  call: れんか
+  call: れんたん
   profile_url: https://www.nogizaka46.com/s/n46/artist/36750
 - id: umezawa_minami
   name: 梅澤 美波
@@ -441,7 +441,7 @@
   color2_name: 緑
   icon: /icons/sample.png
   active: false
-  call:
+  call: よだちゃん
 - id: endo_sakura
   name: 遠藤 さくら
   gen: 4期生
@@ -578,7 +578,7 @@
   color2_name: 黄緑
   icon: /icons/sample.png
   active: true
-  call: ゆみき
+  call: ゆみっきー
   profile_url: https://www.nogizaka46.com/s/n46/artist/55387
 - id: ioki_mao
   name: 五百城 茉央

--- a/src/App.css
+++ b/src/App.css
@@ -261,7 +261,7 @@ h1 {
 	text-overflow: ellipsis;
 }
 
-.member-gen {
+.member-call {
 	font-size: 0.75rem;
 	color: #777;
 	flex-shrink: 0;
@@ -431,7 +431,7 @@ h1 {
 	margin: 0;
 }
 
-.quiz-member-gen {
+.quiz-member-call {
 	font-size: 0.9rem;
 	color: #888;
 	text-align: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,7 +153,7 @@ function App() {
 			if (genFilter && m.gen !== genFilter) return false;
 			if (search) {
 				const q = search.toLowerCase();
-				const fields = [m.name, m.gen, m.color1_name, m.color2_name].filter(
+				const fields = [m.name, m.call, m.color1_name, m.color2_name].filter(
 					isNonEmptyString,
 				);
 				return fields.some((f) => f.toLowerCase().includes(q));
@@ -217,7 +217,7 @@ function App() {
 							<input
 								type="text"
 								className="search-input"
-								placeholder="名前・期・色名で検索..."
+								placeholder="名前・コール・色名で検索..."
 								value={inputValue}
 								onChange={(e) => {
 									setInputValue(e.target.value);

--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -21,7 +21,7 @@ export function MemberCard({ member, isCenter = false }: MemberCardProps) {
 		>
 			<div className="member-header">
 				<span className="member-name">{member.name}</span>
-				{member.gen && <span className="member-gen">{member.gen}</span>}
+				{member.call && <span className="member-call">{member.call}</span>}
 				{isCenter && <span className="center-badge">👑</span>}
 				{member.active === true && member.profile_url && (
 					<a

--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -14,6 +14,7 @@ export function MemberCard({ member, isCenter = false }: MemberCardProps) {
 		: undefined;
 	const color1Valid = isValidHex(hex1);
 	const color2Valid = hex2 ? isValidHex(hex2) : false;
+	const label = member.call || member.gen;
 
 	return (
 		<div
@@ -21,7 +22,7 @@ export function MemberCard({ member, isCenter = false }: MemberCardProps) {
 		>
 			<div className="member-header">
 				<span className="member-name">{member.name}</span>
-				{member.call && <span className="member-call">{member.call}</span>}
+				{label && <span className="member-call">{label}</span>}
 				{isCenter && <span className="center-badge">👑</span>}
 				{member.active === true && member.profile_url && (
 					<a

--- a/src/components/QuizPanel.tsx
+++ b/src/components/QuizPanel.tsx
@@ -43,8 +43,8 @@ export function QuizPanel({ members }: QuizPanelProps) {
 				<p className="quiz-question">
 					Q: {currentMember.name}のサイリウムカラーは?
 				</p>
-				{currentMember.gen && (
-					<p className="quiz-member-gen">{currentMember.gen}</p>
+				{currentMember.call && (
+					<p className="quiz-member-call">{currentMember.call}</p>
 				)}
 				{!answered ? (
 					<button

--- a/src/components/QuizPanel.tsx
+++ b/src/components/QuizPanel.tsx
@@ -36,7 +36,7 @@ export function QuizPanel({ members }: QuizPanelProps) {
 	const answerText = currentMember.color2_name
 		? `${currentMember.color1_name} x ${currentMember.color2_name}`
 		: currentMember.color1_name;
-	const memberHint = currentMember.call || currentMember.gen;
+	const memberHints = [currentMember.gen, currentMember.call].filter(Boolean);
 
 	return (
 		<div className="quiz-panel">
@@ -44,7 +44,9 @@ export function QuizPanel({ members }: QuizPanelProps) {
 				<p className="quiz-question">
 					Q: {currentMember.name}のサイリウムカラーは?
 				</p>
-				{memberHint && <p className="quiz-member-call">{memberHint}</p>}
+				{memberHints.length > 0 && (
+					<p className="quiz-member-call">{memberHints.join(" / ")}</p>
+				)}
 				{!answered ? (
 					<button
 						type="button"

--- a/src/components/QuizPanel.tsx
+++ b/src/components/QuizPanel.tsx
@@ -36,6 +36,7 @@ export function QuizPanel({ members }: QuizPanelProps) {
 	const answerText = currentMember.color2_name
 		? `${currentMember.color1_name} x ${currentMember.color2_name}`
 		: currentMember.color1_name;
+	const memberHint = currentMember.call || currentMember.gen;
 
 	return (
 		<div className="quiz-panel">
@@ -43,9 +44,7 @@ export function QuizPanel({ members }: QuizPanelProps) {
 				<p className="quiz-question">
 					Q: {currentMember.name}のサイリウムカラーは?
 				</p>
-				{currentMember.call && (
-					<p className="quiz-member-call">{currentMember.call}</p>
-				)}
+				{memberHint && <p className="quiz-member-call">{memberHint}</p>}
 				{!answered ? (
 					<button
 						type="button"


### PR DESCRIPTION
This pull request updates the app to display and search by the `call` property instead of `gen` for members. The changes ensure that member call signs are shown in the UI and used in search and quiz features, and corresponding CSS class names are updated for clarity.

**UI and Functionality Updates:**

* The member card now displays `member.call` instead of `member.gen` and uses the updated CSS class name `member-call`. (`src/components/MemberCard.tsx`, `src/App.css`) [[1]](diffhunk://#diff-f5518cc8e7452ea1c347091743979d9a898dabd36d03ea9ec48111618e7debccL24-R24) [[2]](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972L264-R264)
* The quiz panel now shows `member.call` instead of `member.gen`, with the class name changed to `quiz-member-call`. (`src/components/QuizPanel.tsx`, `src/App.css`) [[1]](diffhunk://#diff-47e4527ca38fc253596e008afce340f45a3d21b1b4dcc90003913524b3df7d36L46-R47) [[2]](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972L434-R434)
* The search functionality now includes `call` in the searchable fields instead of `gen`, and the search input placeholder is updated accordingly. (`src/App.tsx`) [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L156-R156) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L220-R220)

**CSS Class Renaming:**

* Renamed `.member-gen` to `.member-call` and `.quiz-member-gen` to `.quiz-member-call` for consistency with the data displayed. (`src/App.css`) [[1]](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972L264-R264) [[2]](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972L434-R434)